### PR TITLE
Fixed typo in SVG attribute name

### DIFF
--- a/src/inline-svg.svelte
+++ b/src/inline-svg.svelte
@@ -106,7 +106,7 @@
 </script>
 
 <svg
-  xmlmns="http://www.w3.org/2000/svg"
+  xmlns="http://www.w3.org/2000/svg"
   bind:innerHTML={svgContent}
   {...svgAttrs}
   {...exclude($$props, ['src', 'transformSrc'])}


### PR DESCRIPTION
Thank you for this plugin!

I found a small typo with the attribute name while I was testing your plugin.
It should be `xmlns`, not `xmlmns`. It's used for declaring the default namespace.

More info: https://developer.mozilla.org/en-US/docs/Web/SVG/Namespaces_Crash_Course