### PR TITLE
Make transformSrc type optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-inline-svg",
-  "version": "1.1.1",
+  "version": "1.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-inline-svg",
-      "version": "1.1.1",
+      "version": "1.1.4",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-inline-svg",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Inline SVGs in Svelte",
   "main": "dist/index.js",
   "exports": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,7 @@ import { SvelteComponentTyped } from 'svelte'
 
 export declare class InlineSvgProps {
   src: string
-  transformSrc: (src: SVGElement) => SVGElement;
+  transformSrc?: (src: SVGElement) => SVGElement;
   [attribute: string]: any
 }
 


### PR DESCRIPTION
I've made the `transformSrc` an optional parameter, as mentioned here https://github.com/robinscholz/svelte-inline-svg/issues/25#issuecomment-1125485105. I've also realised that the reason the types are playing up - besides the missing entry in the package.json `files` key, which you fixed - is that the last release didn't include the `dist` folder in the package at all. It seems like a manual process, so I think it's just something to check before publishing.