### PR TITLE
Remove contenteditable

### DIFF
--- a/src/inline-svg.svelte
+++ b/src/inline-svg.svelte
@@ -105,7 +105,8 @@
 <svg
   use:forwardEvents
   xmlns="http://www.w3.org/2000/svg"
-  bind:innerHTML={svgContent}
   {...svgAttrs}
   {...$$restProps}
-  contenteditable="true" />
+>
+  {@html svgContent}
+</svg>


### PR DESCRIPTION
Removed `contenteditable` and the two-way binding of the inner html. Instead went with the html template syntax found https://svelte.dev/docs#template-syntax-html

Closes #30 